### PR TITLE
Add support for custom events

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,8 @@ var defaults = {
 function trigger(el, name, options){
   var event, type;
   
-  type = eventTypes[name];
-  if (!type) {
-    throw new SyntaxError('Unknown event type: '+type);
-  }
-  
+  type = eventTypes[name] || 'CustomEvent';
+
   options = options || {};
   inherit(defaults, options);
   
@@ -107,5 +104,8 @@ var initializers = {
     return event.initMouseEvent(name, o.bubbles, o.cancelable, document.defaultView, 
           clicks, screenX, screenY, o.clientX, o.clientY,
           o.ctrlKey, o.altKey, o.shiftKey, o.metaKey, button, el);
+  },
+  CustomEvent: function(el, name, event, o){
+    return event.initCustomEvent(name, o.bubbles, o.cancelable, o.detail);
   }
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -57,5 +57,19 @@ describe('triggering', function(){
       }
     });
   });
-  
+
+  describe('CustomEvents', function(){
+    it('triggers single custom event with detail', function(){
+      var calls = 0;
+      function called(evt){
+        calls++;
+        assert(evt.detail === 'expected');
+      }
+
+      triggerAndCatch(document.body, 'some-custom-event', {bubbles: true, detail: 'expected'}, called);
+
+      assert(calls === 1);
+    });
+  });
+ 
 })


### PR DESCRIPTION
Triggers custom DOM events for unknown events names instead of throwing an error.
