### PR TITLE
Adds support for keyup/-down and IE

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,9 +4,7 @@
   "description": "Trigger native DOM events",
   "version": "0.0.2",
   "keywords": ["event", "events", "dom", "trigger"],
-  "dependencies": { 
-    "component/inherit": "*"
-  },
+  "dependencies": {},
   "development": {
     "component/event": "*",
     "component/assert": "*"

--- a/index.js
+++ b/index.js
@@ -96,7 +96,6 @@ var initializers = {
   KeyboardEvent: function(el, name, event, o){
 	// This is still incomplete, but useful for unit testing
     if (event.initKeyboardEvent) {
-console.log(event.initKeyboardEvent);
 		return event.initKeyboardEvent(
 			name,
 			o.bubbles,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var inherit = require('inherit');
 module.exports = trigger;
 
 /** 
@@ -45,11 +44,11 @@ var defaults = {
   metaKey: false,
   bubbles: true,
   cancelable: true,
-  view: undefined,
-  key: undefined,
+  view: null,
+  key: '',
   location: 0,
   modifiers: '',
-  repeat: 1,
+  repeat: 0,
   locale: ''
 };
 
@@ -68,7 +67,11 @@ function trigger(el, name, options){
   var event, type;
   
   options = options || {};
-  inherit(defaults, options);
+  for (var attr in defaults) {
+	  if (!options.hasOwnProperty(attr)) {
+		  options[attr] = defaults[attr];
+	  }
+  }
   
   if (document.createEvent) {
     // Standard Event
@@ -93,6 +96,7 @@ var initializers = {
   KeyboardEvent: function(el, name, event, o){
 	// This is still incomplete, but useful for unit testing
     if (event.initKeyboardEvent) {
+console.log(event.initKeyboardEvent);
 		return event.initKeyboardEvent(
 			name,
 			o.bubbles,

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ var eventTypes = {
   blur:        'HTMLEvents', 
   resize:      'HTMLEvents', 
   scroll:      'HTMLEvents', 
-  input:       'HTMLEvents', 
+  input:       'HTMLEvents',
+
+  keyup:	   'KeyboardEvent',
+  keydown:	   'KeyboardEvent',
   
   click:       'MouseEvents',
   dblclick:    'MouseEvents', 
@@ -41,7 +44,13 @@ var defaults = {
   shiftKey: false,
   metaKey: false,
   bubbles: true,
-  cancelable: true
+  cancelable: true,
+  view: undefined,
+  key: undefined,
+  location: 0,
+  modifiers: '',
+  repeat: 1,
+  locale: ''
 };
 
 /**
@@ -80,6 +89,35 @@ function trigger(el, name, options){
 var initializers = {
   HTMLEvents: function(el, name, event, o){
     return event.initEvent(name, o.bubbles, o.cancelable);
+  },
+  KeyboardEvent: function(el, name, event, o){
+	// This is still incomplete, but useful for unit testing
+    if (event.initKeyboardEvent) {
+		return event.initKeyboardEvent(
+			name,
+			o.bubbles,
+			o.cancelable,
+			o.view,
+			'' + o.key,
+			o.location,
+			o.modifiers,
+			o.repeat,
+			o.locale
+		);
+	} else {
+		return event.initKeyEvent(
+			name,
+			o.bubbles,
+			o.cancelable,
+			o.view,
+			o.ctrlKey,
+			o.altKey,
+			o.shiftKey,
+			o.metaKey,
+			o.key,
+			o.key
+		);
+	}
   },
   MouseEvents: function(el, name, event, o){
     var screenX = ('screenX' in o) ? o.screenX : o.clientX;

--- a/test/tests.js
+++ b/test/tests.js
@@ -23,6 +23,25 @@ describe('triggering', function(){
     });
   });
   
+  describe('KeyboardEvent', function(){
+    it('triggers keydown event', function(){
+      var calls = 0;
+      function called(){ calls++; }
+      
+      triggerAndCatch(document.body, 'keydown', called);
+      
+      assert(calls === 1);
+    });
+    
+    it('triggers keyup event', function(){
+      var calls = 0;
+      function called(){ calls++; }
+      
+      triggerAndCatch(document.body, 'keyup', called);
+      
+      assert(calls === 1);
+    });
+  });  
   describe('MouseEvents', function(){
     it('triggers single click event', function(){
       var calls = 0;


### PR DESCRIPTION
Allows user to fire keyboard events like so:

```
   var $el = document.querySelector('input');
   trigger($el, 'keyup', {key: 13});
```

Tested in Chrome (latest) and IE 10.

**Note**: component/inherit is no longer needed
